### PR TITLE
Use UTC time for date objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var tags = require('./tags');
 module.exports = function(buffer) {
   if (buffer.toString('ascii', 0, 5) !== 'Exif\0')
     throw new Error('Invalid EXIF data: buffer should start with "Exif".');
-  
+
   var bigEndian = null;
   if (buffer[6] === 0x49 && buffer[7] === 0x49)
     bigEndian = false;
@@ -11,32 +11,32 @@ module.exports = function(buffer) {
     bigEndian = true;
   else
     throw new Error('Invalid EXIF data: expected byte order marker.');
-  
+
   if (readUInt16(buffer, 8, bigEndian) !== 0x002A)
     throw new Error('Invalid EXIF data: expected 0x002A.');
-  
+
   var ifdOffset = readUInt32(buffer, 10, bigEndian) + 6;
   if (ifdOffset < 8)
     throw new Error('Invalid EXIF data: ifdOffset < 8');
-  
+
   var result = {};
   var ifd0 = readTags(buffer, ifdOffset, bigEndian, tags.exif);
   result.image = ifd0;
-  
+
   var numEntries = readUInt16(buffer, ifdOffset, bigEndian);
   ifdOffset = readUInt32(buffer, ifdOffset + 2 + numEntries * 12, bigEndian);
   if (ifdOffset !== 0)
     result.thumbnail = readTags(buffer, ifdOffset + 6, bigEndian, tags.exif);
-  
+
   if (ifd0.ExifOffset)
     result.exif = readTags(buffer, ifd0.ExifOffset + 6, bigEndian, tags.exif);
-  
+
   if (ifd0.GPSInfo)
     result.gps = readTags(buffer, ifd0.GPSInfo + 6, bigEndian, tags.gps);
-  
+
   if (ifd0.InteropOffset)
     result.interop = readTags(buffer, ifd0.InteropOffset + 6, bigEndian, tags.exif);
-  
+
   return result;
 };
 
@@ -49,22 +49,22 @@ var DATE_KEYS = {
 function readTags(buffer, offset, bigEndian, tags) {
   var numEntries = readUInt16(buffer, offset, bigEndian);
   offset += 2;
-  
+
   var res = {};
   for (var i = 0; i < numEntries; i++) {
     var tag = readUInt16(buffer, offset, bigEndian);
     offset += 2;
-    
+
     var key = tags[tag] || tag;
     var val = readTag(buffer, offset, bigEndian);
-    
+
     if (key in DATE_KEYS)
       val = parseDate(val);
-    
+
     res[key] = val;
     offset += 10;
   }
-  
+
   return res;
 }
 
@@ -75,29 +75,29 @@ function readTag(buffer, offset, bigEndian) {
   var numValues = readUInt32(buffer, offset + 2, bigEndian);
   var valueSize = SIZE_LOOKUP[type - 1];
   var valueOffset = valueSize * numValues <= 4 ? offset + 6 : readUInt32(buffer, offset + 6, bigEndian) + 6;
-    
+
   // Special case for ascii strings
   if (type === 2) {
     var string = buffer.toString('ascii', valueOffset, valueOffset + numValues);
     if (string[string.length - 1] === '\0') // remove null terminator
       string = string.slice(0, -1);
-    
+
     return string;
   }
-  
+
   // Special case for buffers
   if (type === 7)
     return buffer.slice(valueOffset, valueOffset + numValues);
-  
+
   if (numValues === 1)
     return readValue(buffer, valueOffset, bigEndian, type);
-  
+
   var res = [];
   for (var i = 0; i < numValues; i++) {
     res.push(readValue(buffer, valueOffset, bigEndian, type));
     valueOffset += valueSize;
   }
-  
+
   return res;
 }
 
@@ -108,22 +108,22 @@ function readValue(buffer, offset, bigEndian, type) {
 
     case 3: // uint16
       return readUInt16(buffer, offset, bigEndian);
-    
+
     case 4: // uint32
       return readUInt32(buffer, offset, bigEndian);
-    
+
     case 5: // unsigned rational
       return readUInt32(buffer, offset, bigEndian) / readUInt32(buffer, offset + 4, bigEndian);
-    
+
     case 6: // int8
       return buffer.readInt8(offset);
-    
+
     case 8: // int16
       return readInt16(buffer, offset, bigEndian);
-    
+
     case 9: // int32
       return readInt32(buffer, offset, bigEndian);
-    
+
     case 10: // signed rational
       return readInt32(buffer, offset, bigEndian) / readInt32(buffer, offset + 4, bigEndian);
   }
@@ -132,47 +132,47 @@ function readValue(buffer, offset, bigEndian, type) {
 function parseDate(string) {
   if (typeof string !== 'string')
     return null;
-  
+
   var match = string.match(/^(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
   if (!match)
     return null;
-  
-  return new Date(
-    match[1],
-    match[2] - 1,
-    match[3],
-    match[4],
-    match[5],
-    match[6],
-    0
-  );
+
+  var date = new Date();
+  date.setUTCFullYear(match[1]);
+  date.setUTCMonth(match[2] - 1);
+  date.setUTCDate(match[3]);
+  date.setUTCHours(match[4]);
+  date.setUTCMinutes(match[5]);
+  date.setUTCSeconds(match[6]);
+  date.setUTCMilliseconds(0);
+  return date;
 }
 
 // Buffer reading helpers to help switching between endianness
 function readUInt16(buffer, offset, bigEndian) {
   if (bigEndian)
     return buffer.readUInt16BE(offset);
-  
+
   return buffer.readUInt16LE(offset);
 }
 
 function readUInt32(buffer, offset, bigEndian) {
   if (bigEndian)
     return buffer.readUInt32BE(offset);
-  
+
   return buffer.readUInt32LE(offset);
 }
 
 function readInt16(buffer, offset, bigEndian) {
   if (bigEndian)
     return buffer.readInt16BE(offset);
-  
+
   return buffer.readInt16LE(offset);
 }
 
 function readInt32(buffer, offset, bigEndian) {
   if (bigEndian)
     return buffer.readInt32BE(offset);
-  
+
   return buffer.readInt32LE(offset);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ var IMG_0774 = fs.readFileSync(__dirname + '/data/IMG_0774.exif');
 describe('exif-reader', function() {
   it('should read tiff and exif data', function() {
     assert.deepEqual(exif(tetons),
-      { image: 
+      { image:
          { Make: 'Canon',
            Model: 'Canon EOS D60',
            Orientation: 1,
@@ -15,25 +15,25 @@ describe('exif-reader', function() {
            YResolution: 300,
            ResolutionUnit: 2,
            Software: 'Adobe Photoshop CS Windows',
-           ModifyDate: new Date("2006-04-05T05:31:30.000Z"),
+           ModifyDate: new Date("2006-04-04T22:31:30.000Z"),
            Artist: 'Unspecified',
            Copyright: 'Unspecified',
            ExifOffset: 256 },
-        thumbnail: 
+        thumbnail:
          { Compression: 6,
            XResolution: 72,
            YResolution: 72,
            ResolutionUnit: 2,
            ThumbnailOffset: 1102,
            ThumbnailLength: 7050 },
-        exif: 
+        exif:
          { ExposureTime: 0.03333333333333333,
            FNumber: 19,
            ExposureProgram: 2,
            ISO: 100,
            ExifVersion: new Buffer([48, 50, 50, 48]),
-           DateTimeOriginal: new Date("2004-06-17T13:47:02.000Z"),
-           DateTimeDigitized: new Date("2004-06-17T13:47:02.000Z"),
+           DateTimeOriginal: new Date("2004-06-17T06:47:02.000Z"),
+           DateTimeDigitized: new Date("2004-06-17T06:47:02.000Z"),
            ComponentsConfiguration: new Buffer([1, 2, 3, 0]),
            CompressedBitsPerPixel: 9,
            ShutterSpeedValue: 4.906890869140625,
@@ -58,10 +58,10 @@ describe('exif-reader', function() {
            WhiteBalance: 0,
            SceneCaptureType: 0 } });
   });
-  
+
   it('should read gps data and other exif data', function() {
     assert.deepEqual(exif(IMG_0774),
-      { image: 
+      { image:
          { Make: 'Apple',
            Model: 'iPhone 6',
            Orientation: 1,
@@ -69,17 +69,17 @@ describe('exif-reader', function() {
            YResolution: 72,
            ResolutionUnit: 2,
            Software: 'Photos 1.0',
-           ModifyDate: new Date("2015-03-01T01:13:57.000Z"),
+           ModifyDate: new Date("2015-02-28T17:13:57.000Z"),
            ExifOffset: 198,
            GPSInfo: 1008 },
-        exif: 
+        exif:
          { ExposureTime: 0.0020491803278688526,
            FNumber: 2.2,
            ExposureProgram: 2,
            ISO: 32,
            ExifVersion: new Buffer([48, 50, 50, 49]),
-           DateTimeOriginal: new Date("2015-03-01T01:13:57.000Z"),
-           DateTimeDigitized: new Date("2015-03-01T01:13:57.000Z"),
+           DateTimeOriginal: new Date("2015-02-28T17:13:57.000Z"),
+           DateTimeDigitized: new Date("2015-02-28T17:13:57.000Z"),
            ComponentsConfiguration: new Buffer([1, 2, 3, 0]),
            ShutterSpeedValue: 8.930864197530864,
            ApertureValue: 2.2750072066878064,
@@ -105,7 +105,7 @@ describe('exif-reader', function() {
            LensSpecification: [ 4.15, 4.15, 2.2, 2.2 ],
            LensMake: 'Apple',
            LensModel: 'iPhone 6 back camera 4.15mm f/2.2' },
-        gps: 
+        gps:
          { GPSLatitudeRef: 'N',
            GPSLatitude: [ 35, 18, 1.49 ],
            GPSLongitudeRef: 'W',
@@ -121,18 +121,18 @@ describe('exif-reader', function() {
            GPSDestBearing: 167.44014084507043,
            GPSDateStamp: '2015:03:01' } });
   });
-  
+
   it('should error when missing Exif tag', function() {
     assert.throws(function() {
       exif(new Buffer(50));
     }, /buffer should start with "Exif"/);
   });
-  
+
   it('should error when missing byte order marker', function() {
     assert.throws(function() {
       exif(new Buffer('Exif\0\0IM'));
     }, /expected byte order marker/);
-    
+
     assert.throws(function() {
       exif(new Buffer('Exif\0\0MI'));
     }, /expected byte order marker/);


### PR DESCRIPTION
Closes https://github.com/devongovett/exif-reader/issues/3.

For reference, it's currently impossible to re-use the output for test fixtures as the tests may be run in a different timezone (E.g. Travis: https://travis-ci.org/blakeembrey/node-scrappy/builds/144605673).
