### PR TITLE
Exit early in case of unknown or bogus tag type

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ var SIZE_LOOKUP = [1, 1, 2, 4, 8, 1, 1, 2, 4, 8];
 
 function readTag(buffer, offset, bigEndian) {
   var type = readUInt16(buffer, offset, bigEndian);
+
+  // Exit early in case of unknown or bogus type
+  if (!type || type > SIZE_LOOKUP.length) return null;
+
   var numValues = readUInt32(buffer, offset + 2, bigEndian);
   var valueSize = SIZE_LOOKUP[type - 1];
   var valueOffset = valueSize * numValues <= 4 ? offset + 6 : readUInt32(buffer, offset + 6, bigEndian) + 6;


### PR DESCRIPTION
When parsing corrupted files, I frequently ran into un-catchable errors for invalid tag types. Basically, if the type is invalid, this will cause `undefined` / `NaN` values for `valueSize` and `valueOffset`; because the type is not known `readValue` in the loop at the end of `readTag` will not actually do anything, but keep pushing `undefined` into the `res` array `numValue` times. Given bad input `numValue` can be extremely large so that the loop crashes Node.