### PR TITLE
CI: Add initial, minimal GitHub Actions config to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  - push
+  - pull_request
+permissions: {}
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: current
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
Helps avoid having to manually clone repos and run tests when reviewing Pull Requests.

It's likely that permission needs to be added to this repo (under Settings > Actions) for this to work, something I do not control.