### PR TITLE
Release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exif-reader",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A small EXIF image metadata reader",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Adds support for EXIF metadata that doesn't start with the string "Exif" e.g. PNG `eXIf` chunk - see https://github.com/devongovett/exif-reader/pull/21