### PR TITLE
Tests: include new non-ASCII fixture when fuzzing, run them 10x longer

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tags.js"
   ],
   "scripts": {
-    "test": "UNEXPECTED_CHECK_MAX_ITERATIONS=1000 mocha"
+    "test": "UNEXPECTED_CHECK_MAX_ITERATIONS=10000 mocha"
   },
   "repository": {
     "type": "git",
@@ -29,8 +29,8 @@
   "homepage": "https://github.com/devongovett/exif-reader",
   "devDependencies": {
     "chance-generators": "^3.5.2",
-    "mocha": "^6.2.0",
-    "unexpected": "^11.8.0",
-    "unexpected-check": "^2.2.0"
+    "mocha": "^10.2.0",
+    "unexpected": "^13.1.0",
+    "unexpected-check": "^3.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -249,6 +249,10 @@ describe('fuzz tests', function () {
     expect(pngWithExif, 'when fuzzed by', mutateGenerator(chanceGenerators), 'to either parse or throw documented error');
   });
 
+  it('should parse or reject a randomly mutated EXIF data chunk based on the non_ascii fixture', function () {
+    expect(non_ascii, 'when fuzzed by', mutateGenerator(chanceGenerators), 'to either parse or throw documented error');
+  });
+
   function truncateGenerator(g) {
     return function truncate(buffer) {
       return g.integer({min: 0, max: tetons.length - 1}).map(function (truncateOffset) {
@@ -271,4 +275,7 @@ describe('fuzz tests', function () {
     expect(pngWithExif, 'when fuzzed by', truncateGenerator(chanceGenerators), 'to either parse or throw documented error');
   });
 
+  it('should parse or reject a randomly truncated EXIF data chunk based on the non_ascii fixture', function () {
+    expect(non_ascii, 'when fuzzed by', truncateGenerator(chanceGenerators), 'to either parse or throw documented error');
+  });
 });


### PR DESCRIPTION
Each fuzz test now runs for about 1 second, the whole suite still completes in under 10 seconds.

Also updates all `devDependencies` to latest to avoid audit warnings.