### PR TITLE
Fix type Exif to have property Thumbnail

### DIFF
--- a/exiv2/README.md
+++ b/exiv2/README.md
@@ -17,5 +17,3 @@ As the type information is incomplete for a few tags (e.g. the exif-reader autom
 The website itself is generated based on the output of a tool called `taglist` (part of the Exiv2 project),
 so if the website vanishes, we can still use this tool. (But need some investment of time to build it
 from the C++ sources)
-
-

--- a/exiv2/generate.mjs
+++ b/exiv2/generate.mjs
@@ -26,7 +26,6 @@ const tagsjs = `/**
 ${tagGroups.map(generateTagGroup).join('\n')}
 `
 writeFileSync(join(wd, '..', 'tags.js'), tagsjs);
-//console.log(tagsjs);
 
 const getType = (group, tag, type) => {
   if (numberArrayTags[group]?.includes(tag)) return 'number[]';
@@ -105,7 +104,7 @@ declare namespace exif {
   type Exif = {
     bigEndian: boolean
     ${groups.map((group) => `${group}?: Partial<${group}Tags>`).join('\n    ')}
-    ThumbnailTags?: Partial<ImageTags>
+    Thumbnail?: Partial<ImageTags>
   }
 
 ${tagGroups.map(generateTagGroupTypes).join('\n\n')}

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare namespace exif {
     Photo?: Partial<PhotoTags>
     Iop?: Partial<IopTags>
     GPSInfo?: Partial<GPSInfoTags>
-    ThumbnailTags?: Partial<ImageTags>
+    Thumbnail?: Partial<ImageTags>
   }
 
   type ImageTags = Record<string, GenericTag> & {


### PR DESCRIPTION
The typescript type `Exif` specifies a property `ThumbnailTags` but the implementation sets the property `Thumbnail`. This PR fixes issue #40 .